### PR TITLE
Add non-TH variants of the various logging functions

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -41,6 +41,18 @@ module Control.Monad.Logger
     , logOtherS
     -- * TH util
     , liftLoc
+    -- * Non-TH logging
+    , logDebugN
+    , logInfoN
+    , logWarnN
+    , logErrorN
+    , logOtherN
+    -- * Non-TH logging with source
+    , logDebugNS
+    , logInfoNS
+    , logWarnNS
+    , logErrorNS
+    , logOtherNS
     ) where
 
 import Language.Haskell.TH.Syntax (Lift (lift), Q, Exp, Loc (..), qLocation)
@@ -360,3 +372,46 @@ instance MonadWriter w m => MonadWriter w (LoggingT m) where
   tell   = Trans.lift . tell
   listen = mapLoggingT listen
   pass   = mapLoggingT pass
+
+defaultLoc :: Loc
+defaultLoc = Loc "<unknown>" "<unknown>" "<unknown>" (0,0) (0,0)
+
+logDebugN :: MonadLogger m => Text -> m ()
+logDebugN msg =
+    monadLoggerLog defaultLoc "" LevelDebug msg
+
+logInfoN :: MonadLogger m => Text -> m ()
+logInfoN msg =
+    monadLoggerLog defaultLoc "" LevelInfo msg
+
+logWarnN :: MonadLogger m => Text -> m ()
+logWarnN msg =
+    monadLoggerLog defaultLoc "" LevelWarn msg
+
+logErrorN :: MonadLogger m => Text -> m ()
+logErrorN msg =
+    monadLoggerLog defaultLoc "" LevelError msg
+
+logOtherN :: MonadLogger m => LogLevel -> Text -> m ()
+logOtherN level msg =
+    monadLoggerLog defaultLoc "" level msg
+
+logDebugNS :: MonadLogger m => Text -> Text -> m ()
+logDebugNS src msg =
+    monadLoggerLog defaultLoc src LevelDebug msg
+
+logInfoNS :: MonadLogger m => Text -> Text -> m ()
+logInfoNS src msg =
+    monadLoggerLog defaultLoc src LevelInfo msg
+
+logWarnNS :: MonadLogger m => Text -> Text -> m ()
+logWarnNS src msg =
+    monadLoggerLog defaultLoc src LevelWarn msg
+
+logErrorNS :: MonadLogger m => Text -> Text -> m ()
+logErrorNS src msg =
+    monadLoggerLog defaultLoc src LevelError msg
+
+logOtherNS :: MonadLogger m => Text -> LogLevel -> Text -> m ()
+logOtherNS src level msg =
+    monadLoggerLog defaultLoc src level msg


### PR DESCRIPTION
Recently I ran into some difficulties with a project on Linux, where I had to build an FFI wrapper around a shared library that needed to link back to a static object in my project.  This was simply not possible to do on Linux (after about 8 hours of trying) -- although it worked just fine on the Mac.

The problem lay in how template Haskell tries to dynamically load objects during compilation.  The answer was finally to remove TH from my program.  However, the core library uses `MonadLogger`, and so I wanted to use the monad-logger framework in the code that couldn't use template Haskell.  To do that, I needed non-template Haskell variants of the various logging functions.

I figure that for people who don't care about the source location of their messages (such as me in this case), these functions might be valuable for them as well.
