### PR TITLE
Add a lower-bound on unix-time

### DIFF
--- a/wai-logger/wai-logger.cabal
+++ b/wai-logger/wai-logger.cabal
@@ -32,7 +32,7 @@ Library
                       , old-locale
   else
       Build-Depends:    unix
-                      , unix-time
+                      , unix-time >= 0.2.2
 
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0


### PR DESCRIPTION
This took quite a while to find - Somewhere way down the dep chain, Yesod depends on this, and I was having all sorts of problems trying to get Yesod (re)installed.
