### PR TITLE
Revert "stopping exporting nunnecessary funcs."

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -13,6 +13,8 @@ module System.Log.FastLogger (
   -- * Log messages
   , LogStr
   , ToLogStr(..)
+  , logStrLength
+  , logStrBuilder
   -- * Writing a log message
   , pushLogStr
   -- * Flushing buffered log messages


### PR DESCRIPTION
This reverts commit 8d6bb06ff9ddfd873eaa39927e17c935df288004.

This is necessary to fix wai-extra, see: https://github.com/yesodweb/wai/issues/208
