### PR TITLE
Make use of Template Haskell optional

### DIFF
--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -12,10 +12,15 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 
+flag template_haskell {
+      Description: Enable Template Haskell support
+      Default:     True
+      Manual:      True
+}
+
 library
   exposed-modules:     Control.Monad.Logger
   build-depends:       base               >= 4         && < 5
-                     , template-haskell
                      , transformers
                      , text
                      , stm
@@ -29,3 +34,8 @@ library
                      , monad-loops
                      , mtl
                      , bytestring
+  if flag(template_haskell)
+     build-depends:     template-haskell
+
+  if flag(template_haskell)
+     cpp-options: -DWITH_TEMPLATE_HASKELL


### PR DESCRIPTION
This allows monad-logger to be cross-compiled by a stage 1 GHC compiler or compiled in a platform without `ghc --interactive` support (eg: ARM)

Support can be disabled by invoking cabal with the `--flags="-template_haskell"` option.
