### PR TITLE
Ensure 'BufSize' >= 1.

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -53,13 +53,14 @@ data LoggerSet = LoggerSet (Maybe FilePath) (IORef FD) (Array Int Logger)
 -- | Creating a new 'LoggerSet'.
 --   If 'Nothing' is specified to the second argument,
 --   stdout is used.
+--   Please note that the minimum 'BufSize' is 1.
 newLoggerSet :: BufSize -> Maybe FilePath -> IO LoggerSet
 newLoggerSet size mfile = do
     fd <- case mfile of
         Nothing   -> return stdout
         Just file -> logOpen file
     n <- getNumCapabilities
-    loggers <- replicateM n $ newLogger size
+    loggers <- replicateM n $ newLogger (max 1 size)
     let arr = listArray (0,n-1) loggers
     fref <- newIORef fd
     return $ LoggerSet mfile fref arr

--- a/fast-logger/System/Log/FastLogger/Logger.hs
+++ b/fast-logger/System/Log/FastLogger/Logger.hs
@@ -34,7 +34,7 @@ pushLog :: FD -> Logger -> LogStr -> IO ()
 pushLog fd logger@(Logger mbuf size ref) nlogmsg@(LogStr nlen nbuilder)
   | nlen > size = do
       flushLog fd logger
-      withMVar mbuf $ \buf -> toBufIOWith buf nlen (write fd) nbuilder
+      withMVar mbuf $ \buf -> toBufIOWith buf size (write fd) nbuilder
   | otherwise = do
     mmsg <- atomicModifyIORef' ref checkBuf
     case mmsg of


### PR DESCRIPTION
Also fix typo which treats the log message length as buffer size,
thereby causing memory corruption if the latter is less than the former.
