### PR TITLE
Fix for monad-control-1.0.0.0

### DIFF
--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -31,7 +31,7 @@ library
                      , conduit-extra      >= 1.0       && < 1.3
                      , fast-logger        >= 2.0       && < 2.3
                      , transformers-base
-                     , monad-control      >= 1.0       && < 1.1
+                     , monad-control
                      , monad-loops
                      , mtl
                      , bytestring


### PR DESCRIPTION
Fix `monad-logger` to use `monad-control-1.0.0.0` or later, which uses associated type synonyms instead of associated data for `MonadTransControl` and `MonadBaseControl`.
