### PR TITLE
Transformers compat

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -99,10 +99,7 @@ import Control.Monad.Trans.Identity ( IdentityT)
 import Control.Monad.Trans.List     ( ListT    )
 import Control.Monad.Trans.Maybe    ( MaybeT   )
 import Control.Monad.Trans.Error    ( ErrorT, Error)
-
-#if MIN_VERSION_transformers(0,4,0)
 import Control.Monad.Trans.Except   ( ExceptT  )
-#endif
 
 import Control.Monad.Trans.Reader   ( ReaderT  )
 import Control.Monad.Trans.Cont     ( ContT  )
@@ -202,11 +199,7 @@ instance MonadLogger m => MonadLogger (IdentityT m) where DEF
 instance MonadLogger m => MonadLogger (ListT m) where DEF
 instance MonadLogger m => MonadLogger (MaybeT m) where DEF
 instance (MonadLogger m, Error e) => MonadLogger (ErrorT e m) where DEF
-
-#if MIN_VERSION_transformers(0,4,0)
 instance MonadLogger m => MonadLogger (ExceptT e m) where DEF
-#endif
-
 instance MonadLogger m => MonadLogger (ReaderT r m) where DEF
 instance MonadLogger m => MonadLogger (ContT r m) where DEF
 instance MonadLogger m => MonadLogger (StateT s m) where DEF
@@ -224,11 +217,7 @@ instance MonadLoggerIO m => MonadLoggerIO (IdentityT m)
 instance MonadLoggerIO m => MonadLoggerIO (ListT m)
 instance MonadLoggerIO m => MonadLoggerIO (MaybeT m)
 instance (MonadLoggerIO m, Error e) => MonadLoggerIO (ErrorT e m)
-
-#if MIN_VERSION_transformers(0,4,0)
 instance MonadLoggerIO m => MonadLoggerIO (ExceptT e m)
-#endif
-
 instance MonadLoggerIO m => MonadLoggerIO (ReaderT r m)
 instance MonadLoggerIO m => MonadLoggerIO (ContT r m)
 instance MonadLoggerIO m => MonadLoggerIO (StateT s m)

--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -21,16 +21,17 @@ flag template_haskell {
 
 library
   exposed-modules:     Control.Monad.Logger
-  build-depends:       base               >= 4         && < 5
+  build-depends:       base                >= 4         && < 5
                      , transformers
+                     , transformers-compat >= 0.3
                      , text
                      , stm
                      , stm-chans
                      , lifted-base
-                     , resourcet          >= 0.4       && < 1.2
-                     , conduit            >= 1.0       && < 1.3
-                     , conduit-extra      >= 1.0       && < 1.3
-                     , fast-logger        >= 2.0       && < 2.3
+                     , resourcet           >= 0.4       && < 1.2
+                     , conduit             >= 1.0       && < 1.3
+                     , conduit-extra       >= 1.0       && < 1.3
+                     , fast-logger         >= 2.0       && < 2.3
                      , transformers-base
                      , monad-control
                      , monad-loops

--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -13,6 +13,10 @@ cabal-version:       >=1.8
 extra-source-files:  ChangeLog.md
                      README.md
 
+source-repository head
+  type:              git
+  location:          https://github.com/kazu-yamamoto/logger.git
+
 flag template_haskell {
       Description: Enable Template Haskell support
       Default:     True


### PR DESCRIPTION
This is needed to allow reverse-dependencies of this package to migrate to `ExceptT` while keeping backwards compatibility for older versions of `transformers`.

Also see https://github.com/fpco/stackage/issues/439

I also added the source repository to the .cabal file to allow `cabal get -s`.
