### PR TITLE
Use bytestring-builder instead of blaze-builder

### DIFF
--- a/fast-logger/System/Log/FastLogger/IO.hs
+++ b/fast-logger/System/Log/FastLogger/IO.hs
@@ -1,14 +1,9 @@
-{-# LANGUAGE BangPatterns, CPP #-}
+{-# LANGUAGE BangPatterns #-}
 
 module System.Log.FastLogger.IO where
 
-#if MIN_VERSION_bytestring(0,10,2)
 import Data.ByteString.Builder.Extra (Next(..))
 import qualified Data.ByteString.Builder.Extra as BBE
-#else
-import Blaze.ByteString.Builder.Internal.Types (Builder(..), BuildSignal(..), BufRange(..), runBuildStep, buildStep)
-import Foreign.Ptr (minusPtr)
-#endif
 import Data.ByteString.Internal (ByteString(..))
 import Data.Word (Word8)
 import Foreign.ForeignPtr (withForeignPtr)
@@ -31,7 +26,6 @@ getBuffer = mallocBytes
 freeBuffer :: Buffer -> IO ()
 freeBuffer = free
 
-#if MIN_VERSION_bytestring(0,10,2)
 toBufIOWith :: Buffer -> BufSize -> (Buffer -> Int -> IO ()) -> Builder -> IO ()
 toBufIOWith buf !size io builder = loop $ BBE.runBuilder builder
   where
@@ -46,25 +40,3 @@ toBufIOWith buf !size io builder = loop $ BBE.runBuilder builder
              Chunk (PS fptr off siz) writer'
                | len == 0  -> loop writer' -- flushing
                | otherwise -> withForeignPtr fptr $ \ptr -> io (ptr `plusPtr` off) siz
-#else
-toBufIOWith :: Buffer -> BufSize -> (Buffer -> Int -> IO ()) -> Builder -> IO ()
-toBufIOWith buf !size io (Builder build) = loop firstStep
-  where
-    firstStep = build (buildStep finalStep)
-    finalStep (BufRange p _) = return $ Done p ()
-    bufRange = BufRange buf (buf `plusPtr` size)
-    loop step = do
-        signal <- runBuildStep step bufRange
-        case signal of
-             Done ptr _ -> io buf (ptr `minusPtr` buf)
-             BufferFull minSize ptr next
-               | size < minSize -> error "toBufIOWith: BufferFull: minSize"
-               | otherwise      -> do
-                   io buf (ptr `minusPtr` buf)
-                   loop next
-             InsertByteString ptr (PS fptr off siz) next -> do
-                 io buf (ptr `minusPtr` buf)
-                 withForeignPtr fptr $ \p -> io (p `plusPtr` off) siz
-                 loop next
-#endif
-

--- a/fast-logger/System/Log/FastLogger/LogStr.hs
+++ b/fast-logger/System/Log/FastLogger/LogStr.hs
@@ -11,13 +11,8 @@ module System.Log.FastLogger.LogStr (
   , (<>)
   ) where
 
-#if MIN_VERSION_bytestring(0,10,2)
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as B
-#else
-import qualified Blaze.ByteString.Builder as BB
-import Blaze.ByteString.Builder.Internal.Types as BB (Builder(..))
-#endif
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as S8
 import Data.ByteString.Internal (ByteString(..))
@@ -40,18 +35,10 @@ import qualified Data.Text.Lazy.Encoding as TL
 #endif
 
 toBuilder :: ByteString -> Builder
-#if MIN_VERSION_bytestring(0,10,2)
 toBuilder = B.byteString
-#else
-toBuilder = BB.fromByteString
-#endif
 
 fromBuilder :: Builder -> ByteString
-#if MIN_VERSION_bytestring(0,10,2)
 fromBuilder = BL.toStrict . B.toLazyByteString
-#else
-fromBuilder = BB.toByteString
-#endif
 
 ----------------------------------------------------------------
 

--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -21,9 +21,8 @@ Library
   Build-Depends:        base >= 4 && < 5
                       , array
                       , auto-update >= 0.1.2
-                      -- FIXME: blaze-builder should be removed someday
-                      , blaze-builder
                       , bytestring
+                      , bytestring-builder
                       , directory
                       , filepath
                       , text


### PR DESCRIPTION
Currently, `fast-logger` won't build correctly with `blaze-builder-0.4` on GHC 7.6 (see [here](https://travis-ci.org/scotty-web/scotty/builds/51881488#L315) for example), since `blaze-builder-0.4` doesn't export the `Blaze.ByteString.Builder.Internal.Types` module anymore. I think the simplest workaround is to remove the `bytestring-builder` dependency altogether on depend on `bytestring-builder` instead, which would reduce of the number of code paths due to CPP as a bonus.