### PR TITLE
Re-export LogStr from fast-logger

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -26,6 +26,9 @@ module Control.Monad.Logger
       MonadLogger(..)
     , LogLevel(..)
     , LogSource
+    -- * Re-export from fast-logger
+    , LogStr
+    , ToLogStr(..)
     -- * Helper transformer
     , LoggingT (..)
     , runStderrLoggingT


### PR DESCRIPTION
`LogStr` is required to define custom loggers.