### PR TITLE
Fix Windows build with time-1.5

### DIFF
--- a/wai-logger/Network/Wai/Logger/Date.hs
+++ b/wai-logger/Network/Wai/Logger/Date.hs
@@ -19,8 +19,12 @@ import Control.AutoUpdate (mkAutoUpdate, defaultUpdateSettings, updateAction)
 import Data.ByteString (ByteString)
 #if WINDOWS
 import qualified Data.ByteString.Char8 as BS
-import Data.Time
-import System.Locale
+import Data.Time (UTCTime, formatTime, getCurrentTime, utcToLocalZonedTime)
+# if MIN_VERSION_time(1,5,0)
+import Data.Time (defaultTimeLocale)
+# else
+import System.Locale (defaultTimeLocale)
+# endif
 #else
 import Data.UnixTime (formatUnixTime, fromEpochTime)
 import System.Posix (EpochTime, epochTime)


### PR DESCRIPTION
`time-1.5` changed the type signature of `formatTime` and now exports `defaultTimeLocale`, which clashes with `defaultTimeLocale` from `old-locale`. This causes `wai-logger` to fail when building on Windows using `time-1.5`. This commit uses CPP pragmas to fix the issue.