### PR TITLE
Restore compatibility with bytestring < 0.10

### DIFF
--- a/fast-logger/System/Log/FastLogger/LogStr.hs
+++ b/fast-logger/System/Log/FastLogger/LogStr.hs
@@ -38,7 +38,11 @@ toBuilder :: ByteString -> Builder
 toBuilder = B.byteString
 
 fromBuilder :: Builder -> ByteString
+#if MIN_VERSION_bytestring(0,10,0)
 fromBuilder = BL.toStrict . B.toLazyByteString
+#else
+fromBuilder = BS.concat . BL.toChunks . B.toLazyByteString
+#endif
 
 ----------------------------------------------------------------
 

--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -19,7 +19,7 @@ Library
                         System.Log.FastLogger.IORef
                         System.Log.FastLogger.LogStr
                         System.Log.FastLogger.Logger
-  Build-Depends:        base >= 4 && < 5
+  Build-Depends:        base >= 4.4 && < 5
                       , array
                       , auto-update >= 0.1.2
                       , bytestring


### PR DESCRIPTION
and declare lower bounds `base >= 4.4` as `fast-logger` doesn't
build with GHC 7.0 anymore

See also https://github.com/haskell-infra/hackage-trustees/issues/27