### PR TITLE
Stack and doctest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .cabal-sandbox/
 cabal.sandbox.config
 .stack-work/
+tarballs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ script:
  # hoops because of problems with wai-extra, see:
  # https://github.com/kazu-yamamoto/logger/issues/42
  - cabal install --enable-tests --enable-benchmarks --force-reinstalls wai-extra $PACKAGE_LIST
- - cabal install --run-tests $PACKAGE_LIST
+ - cabal install --run-tests --force-reinstalls $PACKAGE_LIST

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ addons:
         sources:
             - hvr-ghc
         packages:
-            - cabal-install-1.20
+            - cabal-install-1.22
             - ghc-7.6.3
             - ghc-7.8.4
             - ghc-7.10.1
             - ghc-7.10.2
 
 env:
- - CABALVER=1.20 GHCVER=7.6.3
- - CABALVER=1.20 GHCVER=7.8.4
- - CABALVER=1.20 GHCVER=7.10.1
- - CABALVER=1.20 GHCVER=7.10.2
+ - GHCVER=7.6.3
+ - GHCVER=7.8.4
+ - GHCVER=7.10.1
+ - GHCVER=7.10.2
 
 before_install:
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$HOME/.cabal/bin:$PATH
 
 install:
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
+sudo: false
+
+addons:
+    apt:
+        sources:
+            - hvr-ghc
+        packages:
+            - cabal-install-1.20
+            - ghc-7.6.3
+            - ghc-7.8.4
+            - ghc-7.10.1
+            - ghc-7.10.2
+
 env:
  - CABALVER=1.20 GHCVER=7.6.3
  - CABALVER=1.20 GHCVER=7.8.4
@@ -5,9 +18,6 @@ env:
  - CABALVER=1.20 GHCVER=7.10.2
 
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install hspec doctest cabal-meta cabal-src
 
 script:
- - cabal-meta install --only-dependencies --run-tests --enable-benchmarks --force-reinstalls
+ - cabal install --run-tests --enable-benchmarks --force-reinstalls ./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
-language: haskell
+env:
+ - CABALVER=1.20 GHCVER=7.6.3
+ - CABALVER=1.20 GHCVER=7.8.4
+ - CABALVER=1.20 GHCVER=7.10.1
+ - CABALVER=1.20 GHCVER=7.10.2
 
-ghc:
-    - "7.6"
-    - "7.8"
-    - "7.10"
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
 
 install:
-    - ghc --version
-    - cabal --version
-    - cabal install hspec doctest cabal-meta cabal-src
-    - cabal-meta install --force-reinstalls
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install hspec doctest cabal-meta cabal-src
 
-script: mega-sdist --test
+script:
+ - cabal-meta install --only-dependencies --run-tests --enable-benchmarks --force-reinstalls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 env:
   global:
     - CABALVER=1.22
-    - PACKAGE_LIST="./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger"
+    - PACKAGE_LIST="./monad-logger ./wai-logger ./date-cache ./fast-logger"
   matrix:
     - GHCVER=7.6.3
     - GHCVER=7.8.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 env:
   global:
     - CABALVER=1.22
+    - PACKAGE_LIST="./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger"
   matrix:
     - GHCVER=7.6.3
     - GHCVER=7.8.4
@@ -34,4 +35,8 @@ install:
  - travis_retry cabal update
 
 script:
- - cabal install --run-tests --enable-benchmarks --force-reinstalls wai-extra ./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger
+ # First install all packages with dependencies. Have to jump through these
+ # hoops because of problems with wai-extra, see:
+ # https://github.com/kazu-yamamoto/logger/issues/42
+ - cabal install --enable-tests --enable-benchmarks --force-reinstalls wai-extra $PACKAGE_LIST
+ - cabal install --run-tests $PACKAGE_LIST

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,16 @@ addons:
             - ghc-7.10.2
 
 env:
- - GHCVER=7.6.3
- - GHCVER=7.8.4
- - GHCVER=7.10.1
- - GHCVER=7.10.2
+  global:
+    - CABALVER=1.22
+  matrix:
+    - GHCVER=7.6.3
+    - GHCVER=7.8.4
+    - GHCVER=7.10.1
+    - GHCVER=7.10.2
 
 before_install:
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/1.22/bin:$HOME/.cabal/bin:$PATH
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
 
 install:
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ install:
  - travis_retry cabal update
 
 script:
- - cabal install --run-tests --enable-benchmarks --force-reinstalls ./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger
+ - cabal install --run-tests --enable-benchmarks --force-reinstalls wai-extra ./monad-logger ./wai-logger-prefork ./wai-logger ./date-cache ./fast-logger

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ env:
     - GHCVER=7.10.1
     - GHCVER=7.10.2
 
+matrix:
+  allow_failures:
+    # Seems like Travis doesn't reliably have this yet
+    - env: GHCVER=7.10.2
+
 before_install:
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
 

--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -1,5 +1,5 @@
 name:                monad-logger
-version:             0.3.13.1
+version:             0.3.13.2
 synopsis:            A class of monads which can log messages.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/monad-logger>.
 homepage:            https://github.com/kazu-yamamoto/logger
@@ -35,7 +35,7 @@ library
                      , resourcet           >= 0.4       && < 1.2
                      , conduit             >= 1.0       && < 1.3
                      , conduit-extra       >= 1.0       && < 1.3
-                     , fast-logger         >= 2.0       && < 2.4
+                     , fast-logger         >= 2.0       && < 2.5
                      , transformers-base
                      , monad-control
                      , monad-loops

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-2.18
+packages:
+- monad-logger/
+- wai-logger-prefork/
+- wai-logger/
+- date-cache/
+- fast-logger/
+extra-deps:
+- doctest-0.10.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
 resolver: lts-2.18
 packages:
 - monad-logger/
-- wai-logger-prefork/
 - wai-logger/
 - date-cache/
 - fast-logger/

--- a/wai-logger/test/doctests.hs
+++ b/wai-logger/test/doctests.hs
@@ -3,9 +3,4 @@ module Main where
 import Test.DocTest
 
 main :: IO ()
-main = doctest [
-    "-idist/build/autogen/"
-  , "-optP-include"
-  , "-optPdist/build/autogen/cabal_macros.h"
-  , "Network/Wai/Logger.hs"
-  ]
+main = doctest ["Network"]

--- a/wai-logger/wai-logger.cabal
+++ b/wai-logger/wai-logger.cabal
@@ -44,7 +44,7 @@ Test-Suite doctest
   Ghc-Options:          -Wall
   Main-Is:              doctests.hs
   Build-Depends:        base
-                      , doctest
+                      , doctest >= 0.10.1
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
Uses newer doctest with stack support, and adds in stack.yaml. If you wanted, you could also add wai-extra to the test suite dependencies, but then you'd have to use stack, not cabal-install.