### PR TITLE
Safe Haskell

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -1,6 +1,7 @@
 -- | This module provides a fast logging system which
 --   scales on multicore environments (i.e. +RTS -N\<x\>).
 {-# LANGUAGE BangPatterns, CPP #-}
+{-# LANGUAGE Safe #-}
 
 module System.Log.FastLogger (
   -- * Creating a logger set

--- a/fast-logger/System/Log/FastLogger/File.hs
+++ b/fast-logger/System/Log/FastLogger/File.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module System.Log.FastLogger.File where
 
 import Control.Monad (unless, when)

--- a/fast-logger/System/Log/FastLogger/IO.hs
+++ b/fast-logger/System/Log/FastLogger/IO.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE Trustworthy #-}
 
 module System.Log.FastLogger.IO where
 

--- a/fast-logger/System/Log/FastLogger/IORef.hs
+++ b/fast-logger/System/Log/FastLogger/IORef.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Safe #-}
 
 module System.Log.FastLogger.IORef (
        IORef

--- a/fast-logger/System/Log/FastLogger/LogStr.hs
+++ b/fast-logger/System/Log/FastLogger/LogStr.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Safe #-}
 
 module System.Log.FastLogger.LogStr (
     Builder
@@ -13,9 +14,9 @@ module System.Log.FastLogger.LogStr (
 
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as B
+import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as S8
-import Data.ByteString.Internal (ByteString(..))
 import qualified Data.ByteString.Lazy as BL
 #if __GLASGOW_HASKELL__ < 709
 import Data.Monoid (Monoid, mempty, mappend)

--- a/fast-logger/System/Log/FastLogger/Logger.hs
+++ b/fast-logger/System/Log/FastLogger/Logger.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP #-}
+{-# LANGUAGE Safe #-}
 
 module System.Log.FastLogger.Logger (
     Logger(..)

--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE Trustworthy #-}
 -- |  This module provides the facilities needed for a decoupled logging system.
 --
 -- The 'MonadLogger' class is implemented by monads that give access to a

--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -133,13 +133,15 @@ import Control.Monad.Reader.Class ( MonadReader (..) )
 import Control.Monad.State.Class  ( MonadState (..) )
 import Control.Monad.Writer.Class ( MonadWriter (..) )
 
-import Blaze.ByteString.Builder (toByteString)
-
 import Prelude hiding (catch)
 
-#if !MIN_VERSION_fast_logger(2, 1, 0) && MIN_VERSION_bytestring(0, 10, 2)
+#if MIN_VERSION_fast_logger(2, 1, 0)
+-- Using System.Log.FastLogger
+#elif MIN_VERSION_bytestring(0, 10, 2)
 import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Builder (toLazyByteString)
+#else
+import Blaze.ByteString.Builder (toByteString)
 #endif
 
 #if MIN_VERSION_conduit_extra(1,1,0)


### PR DESCRIPTION
Allow use of fast-logger and monad-logger in Safe Haskell. Marked modules as Safe where possible, Trustworthy otherwise.