### PR TITLE
fast-logger + Safe haskell + GHC-7.2 build failure

### DIFF
--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -19,7 +19,7 @@ Library
                         System.Log.FastLogger.IORef
                         System.Log.FastLogger.LogStr
                         System.Log.FastLogger.Logger
-  Build-Depends:        base >= 4.4 && < 5
+  Build-Depends:        base >= 4.5 && < 5
                       , array
                       , auto-update >= 0.1.2
                       , bytestring


### PR DESCRIPTION
```
System/Log/FastLogger/Logger.hs:14:1:
    base:GHC.IO.FD can't be safely imported! The module itself isn't safe.
```

This can be hard to fix so it might be best to just stop supporting GHC-7.2.
