### PR TITLE
Provide default monadLoggerLog implementation

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -177,6 +177,9 @@ type CharPos = (Int, Int)
 -- | A @Monad@ which has the ability to log messages in some manner.
 class Monad m => MonadLogger m where
     monadLoggerLog :: ToLogStr msg => Loc -> LogSource -> LogLevel -> msg -> m ()
+    default monadLoggerLog :: (Trans.MonadTrans t, MonadLogger (t m), ToLogStr msg)
+                           => Loc -> LogSource -> LogLevel -> msg -> t m ()
+    monadLoggerLog loc src lvl msg = Trans.lift $ monadLoggerLog loc src lvl msg
 
 -- | An extension of @MonadLogger@ for the common case where the logging action
 -- is a simple @IO@ action. The advantage of using this typeclass is that the


### PR DESCRIPTION
Provide a default implementation of monadLoggerLog for MonadTrans, similar to that defined for MonadLoggerIO