### PR TITLE
Remove redundant `$!` and unused language pragma.

### DIFF
--- a/date-cache/System/Date/Cache.hs
+++ b/date-cache/System/Date/Cache.hs
@@ -40,7 +40,7 @@ newDate setting tm = DateCache tm <$> formatDate setting tm
 ondemandDateCacher :: Eq t => DateCacheConf t -> IO (DateCacheGetter, DateCacheCloser)
 ondemandDateCacher setting = do
     ref <- getTime setting >>= newDate setting >>= newIORef
-    return $! (getter ref, closer)
+    return (getter ref, closer)
   where
     getter ref = do
         newTm <- getTime setting
@@ -61,7 +61,7 @@ clockDateCacher :: Eq t => DateCacheConf t -> IO (DateCacheGetter, DateCacheClos
 clockDateCacher setting = do
     ref <- getTime setting >>= newDate setting >>= newIORef
     tid <- forkIO $ clock ref
-    return $! (getter ref, closer tid)
+    return (getter ref, closer tid)
   where
     getter ref = formattedDate <$> readIORef ref
     clock ref = do

--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -1,6 +1,6 @@
 -- | This module provides a fast logging system which
 --   scales on multicore environments (i.e. +RTS -N\<x\>).
-{-# LANGUAGE BangPatterns, CPP #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Safe #-}
 
 module System.Log.FastLogger (


### PR DESCRIPTION
Hi Michael :)

I found some suggestions from `hlint` and applied them:

- date-cache/System/Date/Cache.hs: remove redundant `$!`
- fast-logger/System/Log/FastLogger.hs: unused pragma `BangPatterns`

the redundant `$!` occurences where of the form:

```
somefunc = f $! (x,y)
```

which will not do anything because due to the tuple literal the argument to `f` already is in WHNF.

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
