### PR TITLE
log to a chan

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -600,7 +600,7 @@ runChanLoggingT chan = (`runLoggingT` sink chan)
 --   For use in a dedicated thread with a channel fed by `runChanLoggingT`.
 --
 -- Since VERSION
-unChanLoggingT :: MonadLoggerIO m => Chan (Loc, LogSource, LogLevel, LogStr) -> m ()
+unChanLoggingT :: (MonadLogger m, MonadIO m) => Chan (Loc, LogSource, LogLevel, LogStr) -> m ()
 unChanLoggingT chan = forever $ do
     (loc,src,lvl,msg) <- liftIO $ readChan chan
     monadLoggerLog loc src lvl msg

--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -582,7 +582,11 @@ runStderrLoggingT = (`runLoggingT` defaultOutput stderr)
 runStdoutLoggingT :: MonadIO m => LoggingT m a -> m a
 runStdoutLoggingT = (`runLoggingT` defaultOutput stdout)
 
--- | Run a block using a @MonadLogger@ instance which writes tuples to an unbounded channel.
+-- | Run a block using a @MonadLogger@ instance which writes tuples to an
+--   unbounded channel.
+--
+--   The tuples can be extracted (ie. in another thread) with `unChanLoggingT`
+--   or a custom extraction funtion, and written to a destination.
 --
 -- Since VERSION
 runChanLoggingT :: MonadIO m => Chan (Loc, LogSource, LogLevel, LogStr) -> LoggingT m a -> m a
@@ -590,7 +594,10 @@ runChanLoggingT chan = (`runLoggingT` sink chan)
     where
         sink chan loc src lvl msg = writeChan chan (loc,src,lvl,msg)
 
--- | Read tuples from an unbounded channel and log them, forever.
+-- | Read logging tuples from an unbounded channel and log them into a
+--   `MonadLoggerIO` monad, forever.
+--
+--   For use in a dedicated thread with a channel fed by `runChanLoggingT`.
 --
 -- Since VERSION
 unChanLoggingT :: MonadLoggerIO m => Chan (Loc, LogSource, LogLevel, LogStr) -> m ()


### PR DESCRIPTION
This change allows you to log to a channel so that you can more easily use `monad-logger` with a library that exposes its own logging interface (eg, `haxy`, `http-server`).

I made this change because in my program stdout/stderr weren't line-buffered, and logging messages were interlacing. The channel resolves log message ordering from threads and `unChanLoggingT` allows you to extract them all in one place for whatever `run*LoggingT`.

Here's an example of how this is used: https://gist.github.com/plredmond/22a0513972b30c14e32f

* Not sure this is a desired direction of `monad-logging`. Feel free to close.