### PR TITLE
When I log a message longer than 8160 characters, fast-logger just logs a newline

### DIFF
--- a/fast-logger/System/Log/FastLogger/IO.hs
+++ b/fast-logger/System/Log/FastLogger/IO.hs
@@ -40,4 +40,4 @@ toBufIOWith buf !size io builder = loop $ BBE.runBuilder builder
                | otherwise      -> loop writer'
              Chunk (PS fptr off siz) writer'
                | len == 0  -> loop writer' -- flushing
-               | otherwise -> withForeignPtr fptr $ \ptr -> io (ptr `plusPtr` off) siz
+               | otherwise -> withForeignPtr fptr $ \ptr -> io (ptr `plusPtr` off) siz >> loop writer'

--- a/fast-logger/System/Log/FastLogger/IO.hs
+++ b/fast-logger/System/Log/FastLogger/IO.hs
@@ -38,6 +38,5 @@ toBufIOWith buf !size io builder = loop $ BBE.runBuilder builder
              More minSize writer'
                | size < minSize -> error "toBufIOWith: More: minSize"
                | otherwise      -> loop writer'
-             Chunk (PS fptr off siz) writer'
-               | len == 0  -> loop writer' -- flushing
-               | otherwise -> withForeignPtr fptr $ \ptr -> io (ptr `plusPtr` off) siz >> loop writer'
+             Chunk (PS fptr off siz) writer' ->
+               withForeignPtr fptr $ \ptr -> io (ptr `plusPtr` off) siz >> loop writer'

--- a/fast-logger/test/FastLoggerSpec.hs
+++ b/fast-logger/test/FastLoggerSpec.hs
@@ -5,7 +5,7 @@ module FastLoggerSpec where
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative ((<$>))
 #endif
-import Control.Exception (bracket, finally)
+import Control.Exception (finally)
 import Control.Monad (when)
 import qualified Data.ByteString.Char8 as BS
 import Data.Monoid ((<>))
@@ -31,19 +31,28 @@ safeForLarge :: [Int] -> IO ()
 safeForLarge ns = mapM_ safeForLarge' ns
 
 safeForLarge' :: Int -> IO ()
-safeForLarge' n = bracket nullLogger rmLoggerSet $ \lgrset -> do
-    let xs = toLogStr $ BS.pack $ replicate (abs n) 'x'
+safeForLarge' n = flip finally (cleanup tmpfile) $ do
+    cleanup tmpfile
+    lgrset <- newFileLoggerSet defaultBufSize tmpfile
+    let xs = toLogStr $ BS.pack $ take (abs n) (cycle ['a'..'z'])
         lf = "x"
     pushLogStr lgrset $ xs <> lf
     flushLogStr lgrset
+    rmLoggerSet lgrset
+    bs <- BS.readFile tmpfile
+    bs `shouldBe` BS.pack (take (abs n) (cycle ['a'..'z']) <> "x")
+    where
+        tmpfile = "test/temp"
+
+cleanup :: FilePath -> IO ()
+cleanup file = do
+    exist <- doesFileExist file
+    when exist $ removeFile file
 
 logAllMsgs :: IO ()
 logAllMsgs = logAll "LICENSE" `finally` cleanup tmpfile
   where
     tmpfile = "test/temp"
-    cleanup file = do
-        exist <- doesFileExist file
-        when exist $ removeFile file
     logAll file = do
         cleanup tmpfile
         lgrset <- newFileLoggerSet 512 tmpfile


### PR DESCRIPTION
```haskell
import qualified Data.Text as T
import           System.Log.FastLogger

main :: IO ()
main = do
  set <- newStderrLoggerSet defaultBufSize
  let text = T.pack $ replicate 8161 'x'
  pushLogStrLn set (toLogStr text)
```

**Expected output:** lots of `x`s

**Actual output:** (enclused in 2 horizontal bars for better visibility)

---

```

```

---

Fix attached (props to @exFalso and @chpatrick for helping), and a test.

Independent of this, I also noticed that when logging that string, in `toBufIOWith` there comes around a `Done` with `len == 0` as the first thing before the real data comes; I didn't look into why that is.