### PR TITLE
add FastLogger and related helpers

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -28,9 +28,11 @@ module System.Log.FastLogger (
   , flushLogStr
   -- * FastLogger
   , FastLogger(..)
+  , LogType(..)
   , newFastLogger
   , newTimedFastLogger
   , simpleAppendTime
+  , simpleTimeFormat
   -- * Date cache
   , module System.Log.FastLogger.Date
   -- * File rotation
@@ -221,7 +223,7 @@ newFastLogger typ = case typ of
         return $ FastLogger logger' (rmLoggerSet lgrset)
 
 -- | Initialize a 'FastLogger' with timestamp attached to each message.
-newTimedFastLogger :: TimeFormat               -- ^ for example: @\"%d/%b/%Y:%T %z\"@
+newTimedFastLogger :: TimeFormat               -- ^ for example: 'simpleTimeFormat'
     -> (FormattedTime -> LogStr -> LogStr)     -- ^ How do we attach formatted time with message?
     -> LogType -> IO FastLogger
 newTimedFastLogger _ _ LogNone = newFastLogger LogNone
@@ -264,6 +266,9 @@ newTimedFastLogger fmt logf typ = do
 simpleAppendTime :: FormattedTime -> LogStr -> LogStr
 simpleAppendTime t l = l <> "@" <> (toLogStr t)
 
+-- | A simple time format: @simpleTimeFormat = "%d/%b/%Y:%T %z"@
+simpleTimeFormat :: TimeFormat
+simpleTimeFormat = "%d/%b/%Y:%T %z"
 ----------------------------------------------------------------
 
 decrease :: IORef Int -> IO Int

--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -48,7 +48,6 @@ import Control.Exception (handle, SomeException(..), bracket)
 import Control.Monad (when, replicateM)
 import Data.Array (Array, listArray, (!), bounds)
 import Data.Maybe (isJust)
-import Data.Text (Text)
 import System.EasyFile (getFileSize)
 import System.Log.FastLogger.File
 import System.Log.FastLogger.IO
@@ -117,7 +116,7 @@ pushLogStr (LoggerSet _ fref arr flush) logmsg = do
 
 -- | Same as 'pushLogStr' but also appends a newline.
 pushLogStrLn :: LoggerSet -> LogStr -> IO ()
-pushLogStrLn loggerSet logStr = pushLogStr loggerSet (logStr <> toLogStr ("\n" :: Text))
+pushLogStrLn loggerSet logStr = pushLogStr loggerSet (logStr <> "\n")
 
 -- | Flushing log messages in buffers.
 --   This function must be called explicitly when the program is

--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -174,21 +174,22 @@ type FastLogger = LogStr -> IO ()
 type TimedFastLogger = (FormattedTime -> LogStr) -> IO ()
 
 -- | Logger Type.
-data LogType = LogNone                     -- ^ No logging.
-             | LogStdout BufSize           -- ^ Logging to stdout.
-                                           --   'BufSize' is a buffer size
-             | LogStderr BufSize           -- ^ Logging to stdout.
-                                           --   'BufSize' is a buffer size
-                                           --   for each capability.
-             | LogFile FilePath BufSize    -- ^ Logging to a file.
-                                           --   'BufSize' is a buffer size
-                                           --   for each capability.
-             | LogFileAutoRotate FileLogSpec BufSize -- ^ Logging to a file.
-                                           --   'BufSize' is a buffer size
-                                           --   for each capability.
-                                           --   File rotation is done on-demand.
-             | LogCallback (LogStr -> IO ()) (IO ()) -- ^ Logging with a log and flush action.
-                                           -- run flush after log each message.
+data LogType
+    = LogNone                     -- ^ No logging.
+    | LogStdout BufSize           -- ^ Logging to stdout.
+                                  --   'BufSize' is a buffer size
+    | LogStderr BufSize           -- ^ Logging to stdout.
+                                  --   'BufSize' is a buffer size
+                                  --   for each capability.
+    | LogFile FilePath BufSize    -- ^ Logging to a file.
+                                  --   'BufSize' is a buffer size
+                                  --   for each capability.
+    | LogFileAutoRotate FileLogSpec BufSize -- ^ Logging to a file.
+                                  --   'BufSize' is a buffer size
+                                  --   for each capability.
+                                  --   File rotation is done on-demand.
+    | LogCallback (LogStr -> IO ()) (IO ()) -- ^ Logging with a log and flush action.
+                                               -- run flush after log each message.
 
 -- | Initialize a 'FastLogger' without attaching timestamp
 -- a tuple of logger and clean up action are returned.

--- a/fast-logger/System/Log/FastLogger/Date.hs
+++ b/fast-logger/System/Log/FastLogger/Date.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE CPP #-}
+
+-- |
+-- Formatting time is slow.
+-- This package provides mechanisms to cache formatted date.
+module System.Log.FastLogger.Date (
+  -- * Types
+    TimeFormat
+  , FormattedTime
+  -- * Date cacher
+  , newTimeCacher
+  ) where
+
+import Control.AutoUpdate (mkAutoUpdate, defaultUpdateSettings, updateAction)
+import Data.ByteString (ByteString)
+#if WINDOWS
+import qualified Data.ByteString.Char8 as BS
+import Data.Time (UTCTime, formatTime, getCurrentTime, utcToLocalZonedTime)
+# if MIN_VERSION_time(1,5,0)
+import Data.Time (defaultTimeLocale)
+# else
+import System.Locale (defaultTimeLocale)
+# endif
+#else
+import Data.UnixTime (formatUnixTime, fromEpochTime)
+import System.Posix (EpochTime, epochTime)
+#endif
+
+----------------------------------------------------------------
+
+-- | Type aliaes for date format and formatted date.
+type FormattedTime = ByteString
+type TimeFormat = ByteString
+
+----------------------------------------------------------------
+
+#if WINDOWS
+-- | Get date using UTC.
+getTime :: IO UTCTime
+getTime = getCurrentTime
+-- | Format UTC date.
+formatDate :: TimeFormat -> UTCTime -> IO FormattedTime
+formatDate fmt ut = do
+  zt <- utcToLocalZonedTime ut
+  return $ BS.pack $ formatTime defaultTimeLocale (BS.unpack fmt) zt
+#else
+-- | Get date using UnixTime.
+getTime :: IO EpochTime
+getTime = epochTime
+-- | Format unix EpochTime date.
+formatDate :: TimeFormat -> EpochTime -> IO FormattedTime
+formatDate fmt = formatUnixTime fmt . fromEpochTime
+#endif
+
+----------------------------------------------------------------
+
+-- |  Make 'IO' action which get cached formatted local time.
+newTimeCacher :: TimeFormat -> IO (IO FormattedTime)
+newTimeCacher fmt = mkAutoUpdate defaultUpdateSettings{
+        updateAction = getTime >>= formatDate fmt
+    }

--- a/fast-logger/System/Log/FastLogger/File.hs
+++ b/fast-logger/System/Log/FastLogger/File.hs
@@ -14,8 +14,8 @@ data FileLogSpec = FileLogSpec {
   }
 
 -- | Checking if a log file can be written.
-check :: FileLogSpec -> IO ()
-check spec = do
+check :: FilePath -> IO ()
+check file = do
     dirExist <- doesDirectoryExist dir
     unless dirExist $ fail $ dir ++ " does not exist or is not a directory."
     dirPerm <- getPermissions dir
@@ -25,7 +25,6 @@ check spec = do
         perm <- getPermissions file
         unless (writable perm) $ fail $ file ++ " is not writable."
   where
-    file = log_file spec
     dir = takeDirectory file
 
 -- | Rotating log files.

--- a/fast-logger/System/Log/FastLogger/IORef.hs
+++ b/fast-logger/System/Log/FastLogger/IORef.hs
@@ -6,6 +6,7 @@ module System.Log.FastLogger.IORef (
      , newIORef
      , readIORef
      , atomicModifyIORef'
+     , writeIORef
      ) where
 
 import Data.IORef

--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -15,6 +15,7 @@ Library
   GHC-Options:          -Wall
   Exposed-Modules:      System.Log.FastLogger
                         System.Log.FastLogger.File
+                        System.Log.FastLogger.Date
   Other-Modules:        System.Log.FastLogger.IO
                         System.Log.FastLogger.FileIO
                         System.Log.FastLogger.IORef
@@ -23,14 +24,20 @@ Library
   Build-Depends:        base >= 4.5 && < 5
                       , array
                       , auto-update >= 0.1.2
+                      , easy-file >= 0.2
                       , bytestring
                       , bytestring-builder
                       , directory
                       , filepath
                       , text
   if os(windows)
-    Build-Depends:
-                      Win32
+      Cpp-Options:      -DWINDOWS
+      Build-Depends:    time
+                      , Win32
+                      , old-locale
+  else
+      Build-Depends:    unix
+                      , unix-time >= 0.2.2
 
 Test-Suite spec
     Main-Is:         Spec.hs

--- a/wai-logger/Network/Wai/Logger.hs
+++ b/wai-logger/Network/Wai/Logger.hs
@@ -57,7 +57,7 @@ import Control.Monad (when, void)
 import Network.HTTP.Types (Status)
 import Network.Wai (Request)
 import System.EasyFile (getFileSize)
-import System.Log.FastLogger
+import System.Log.FastLogger hiding (LogType(..)) -- TODO: use new FastLogger when ready
 
 import Network.Wai.Logger.Apache
 import Network.Wai.Logger.Date


### PR DESCRIPTION
This is the first step to solve #84, The higher level api then can be used to add `runFastLoggerLoggingT` to monad-logger.

One thing i'm not sure is that i have copied Date.hs from wai-logger to get cached formatted time, i'm not sure i should do this or update it in date-cache and add it as a dependency.