### PR TITLE
fix stdio flush

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -201,7 +201,7 @@ newFastLogger typ = case typ of
     LogFileAutoRotate fspec bsize -> rotateLoggerInit fspec bsize
     LogCallback cb flush -> return (\ str -> cb str >> flush, noOp )
   where
-    stdLoggerInit lgrset = return (pushLogStr lgrset, noOp)
+    stdLoggerInit lgrset = return (pushLogStr lgrset, rmLoggerSet lgrset)
     fileLoggerInit lgrset = return (pushLogStr lgrset, rmLoggerSet lgrset)
     rotateLoggerInit fspec bsize = do
         lgrset <- newFileLoggerSet bsize $ log_file fspec
@@ -231,7 +231,7 @@ newTimedFastLogger tgetter typ = case typ of
     LogFileAutoRotate fspec bsize -> rotateLoggerInit fspec bsize
     LogCallback cb flush -> return (\ f -> tgetter >>= cb . f >> flush, noOp )
   where
-    stdLoggerInit lgrset = return ( \f -> tgetter >>= pushLogStr lgrset . f, noOp)
+    stdLoggerInit lgrset = return ( \f -> tgetter >>= pushLogStr lgrset . f, rmLoggerSet lgrset)
     fileLoggerInit lgrset = return (\f -> tgetter >>= pushLogStr lgrset . f, rmLoggerSet lgrset)
     rotateLoggerInit fspec bsize = do
         lgrset <- newFileLoggerSet bsize $ log_file fspec


### PR DESCRIPTION
I haven't come up with a testing plan for fast-logger yet, but i believe this patch is necessary for correctly flush stdout/stderr, because `rmLoggerSet` will flush stdout/stderr.