### PR TITLE
export defaultLoc and logWithoutLoc

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -73,6 +73,7 @@ module Control.Monad.Logger
     , logErrorN
     , logOtherN
     -- * Non-TH logging with source
+    , logWithoutLoc
     , logDebugNS
     , logInfoNS
     , logWarnNS
@@ -89,6 +90,7 @@ module Control.Monad.Logger
     -- * utilities for defining your own loggers
     , defaultLogStr
     , Loc (..)
+    , defaultLoc
     ) where
 
 #if WITH_TEMPLATE_HASKELL


### PR DESCRIPTION
They are useful for defining custom log functions where the log level is passed as a parameter rather than by choosing the respective function. 
