### PR TITLE
Fix #106 by correcting the default signature for MonadLoggerIO

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -215,8 +215,8 @@ class (MonadLogger m, MonadIO m) => MonadLoggerIO m where
     --
     -- Since 0.3.10
     askLoggerIO :: m (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
-    default askLoggerIO :: (Trans.MonadTrans t, MonadLogger (t m), MonadIO (t m))
-                        => t m (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
+    default askLoggerIO :: (Trans.MonadTrans t, MonadLoggerIO n, m ~ t n)
+                        => m (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
     askLoggerIO = Trans.lift askLoggerIO
 
 


### PR DESCRIPTION
As pointed out in [GHC Trac #12784](https://ghc.haskell.org/trac/ghc/ticket/12784), `monad-logger` is failing to compile on GHC 8.0.2 because it's using a bogus default type signature for `askLoggerIO` in the `MonadLoggerIO` class. Luckily, it's a simple fix.

Fixes #106.