### PR TITLE
Fix a Windows #ifdef

### DIFF
--- a/fast-logger/System/Log/FastLogger/FileIO.hs
+++ b/fast-logger/System/Log/FastLogger/FileIO.hs
@@ -12,7 +12,7 @@ import Graphics.Win32.Misc (getStdHandle, sTD_OUTPUT_HANDLE, sTD_ERROR_HANDLE)
 import Data.Bits ((.|.))
 
 type FD = HANDLE
-#ifdef !MIN_VERSION_win32(2,3,1,0)
+#if !MIN_VERSION_Win32(2,3,1)
 -- This flag is not defined in System.Win32.File
 fILE_APPEND_DATA :: UINT
 fILE_APPEND_DATA = 0x0004


### PR DESCRIPTION
Currently, building `fast-logger` on Windows fails with:

```
Building fast-logger-2.4.8...
Preprocessing library fast-logger-2.4.8...

System\Log\FastLogger\FileIO.hs:15:0: error:
     error: macro names must be identifiers
     #ifdef !MIN_VERSION_win32(2,3,1,0)
     ^
`gcc.exe' failed in phase `C pre-processor'. (Exit code: 1)
```

This fixes it.