### PR TITLE
Fix the GHC 8.2 build

### DIFF
--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -200,8 +200,8 @@ type CharPos = (Int, Int)
 -- | A @Monad@ which has the ability to log messages in some manner.
 class Monad m => MonadLogger m where
     monadLoggerLog :: ToLogStr msg => Loc -> LogSource -> LogLevel -> msg -> m ()
-    default monadLoggerLog :: (Trans.MonadTrans t, MonadLogger (t m), ToLogStr msg)
-                           => Loc -> LogSource -> LogLevel -> msg -> t m ()
+    default monadLoggerLog :: (MonadLogger m', Trans.MonadTrans t, MonadLogger (t m'), ToLogStr msg, m ~ t m')
+                           => Loc -> LogSource -> LogLevel -> msg -> m ()
     monadLoggerLog loc src lvl msg = Trans.lift $ monadLoggerLog loc src lvl msg
 
 -- | An extension of @MonadLogger@ for the common case where the logging action


### PR DESCRIPTION
Currently, `monad-logger` fails to build on GHC 8.2, giving this error:

```
[1 of 2] Compiling Control.Monad.Logger ( Control/Monad/Logger.hs, dist/build/Control/Monad/Logger.o )

Control/Monad/Logger.hs:203:13: error:
    • The default type signature for monadLoggerLog:
        forall (t :: (* -> *) -> * -> *) msg.
        (Trans.MonadTrans t, MonadLogger (t m), ToLogStr msg) =>
        Loc -> LogSource -> LogLevel -> msg -> t m ()
      does not match its corresponding non-default type signature
    • When checking the class method:
        monadLoggerLog :: forall (m :: * -> *).
                          MonadLogger m =>
                          forall msg.
                          ToLogStr msg =>
                          Loc -> LogSource -> LogLevel -> msg -> m ()
      In the class declaration for ‘MonadLogger’
    |
203 |     default monadLoggerLog :: (Trans.MonadTrans t, MonadLogger (t m), ToLogStr msg)
    |             ^^^^^^^^^^^^^^
```

This is because the validity checking for default type signatures tightened up in GHC 8.2 (see also [GHC Trac #12918](https://ghc.haskell.org/trac/ghc/ticket/12918)). In particular, GHC requires that the default type signature of a method must be the same as the non-default type signature, modulo constraints.

This PR fixes the default type signature for `monadLoggerLog` to meet this criterion.