### PR TITLE
Add MonadReader instance for NoLoggingT

### DIFF
--- a/monad-logger/ChangeLog.md
+++ b/monad-logger/ChangeLog.md
@@ -1,3 +1,6 @@
+## 0.3.24
+* Added `MonadReader` instance for `NoLoggingT`.
+
 ## 0.3.23
 * Changed `runFileLoggingT` buffering to line buffering.
 * Added `defaultLog` and `logWithoutLoc` to list of exported functions.

--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -747,6 +747,7 @@ instance MonadReader r m => MonadReader r (LoggingT m) where
   ask = Trans.lift ask
   local = mapLoggingT . local
 
+-- | @since 0.3.24
 instance MonadReader r m => MonadReader r (NoLoggingT m) where
   ask = Trans.lift ask
   local = mapNoLoggingT . local

--- a/monad-logger/Control/Monad/Logger.hs
+++ b/monad-logger/Control/Monad/Logger.hs
@@ -747,6 +747,10 @@ instance MonadReader r m => MonadReader r (LoggingT m) where
   ask = Trans.lift ask
   local = mapLoggingT . local
 
+instance MonadReader r m => MonadReader r (NoLoggingT m) where
+  ask = Trans.lift ask
+  local = mapNoLoggingT . local
+
 mapLoggingT :: (m a -> n b) -> LoggingT m a -> LoggingT n b
 mapLoggingT f = LoggingT . (f .) . runLoggingT
 

--- a/monad-logger/monad-logger.cabal
+++ b/monad-logger/monad-logger.cabal
@@ -1,5 +1,5 @@
 name:                monad-logger
-version:             0.3.23
+version:             0.3.24
 synopsis:            A class of monads which can log messages.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/monad-logger>.
 homepage:            https://github.com/kazu-yamamoto/logger


### PR DESCRIPTION
It was trivial to add. I have a monad stack that is `MonadReader, MonadLogger` for which I wanted to write unit tests, however, I discovered this instance was missing. 