### PR TITLE
Give an explicit definition for (<>) in LogStr's Semigroup instance

### DIFF
--- a/fast-logger/System/Log/FastLogger/LogStr.hs
+++ b/fast-logger/System/Log/FastLogger/LogStr.hs
@@ -25,7 +25,7 @@ import Data.Monoid (Monoid, mempty, mappend)
 import Data.Monoid ((<>))
 #endif
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup)
+import qualified Data.Semigroup as Semi (Semigroup(..))
 #endif
 import Data.String (IsString(..))
 import qualified Data.Text as T
@@ -56,7 +56,8 @@ fromBuilder = BS.concat . BL.toChunks . B.toLazyByteString
 data LogStr = LogStr !Int Builder
 
 #if MIN_VERSION_base(4,9,0)
-instance Semigroup LogStr
+instance Semi.Semigroup LogStr where
+    LogStr s1 b1 <> LogStr s2 b2 = LogStr (s1 + s2) (b1 <> b2)
 #endif
 
 instance Monoid LogStr where


### PR DESCRIPTION
In `base-4.11` (bundled with GHC 8.4.1), there is no longer a default implementation for `(<>)` in terms of `Monoid` (after `Semigroup` became a superclass of `Monoid`), so using `(<>)` results in a runtime error. This fixes the issue by simply giving an implementation for `(<>)` that matches `mappend`.