### PR TITLE
add ToLogStr instance for bytestring builder

### DIFF
--- a/fast-logger/System/Log/FastLogger/LogStr.hs
+++ b/fast-logger/System/Log/FastLogger/LogStr.hs
@@ -75,6 +75,8 @@ instance ToLogStr S8.ByteString where
     toLogStr bs = LogStr (BS.length bs) (toBuilder bs)
 instance ToLogStr BL.ByteString where
     toLogStr = toLogStr . S8.concat . BL.toChunks
+instance ToLogStr Builder where
+    toLogStr x = let b = B.toLazyByteString x in LogStr (fromIntegral (BL.length b)) (B.lazyByteString b)
 instance ToLogStr String where
     toLogStr = toLogStr . TL.pack
 instance ToLogStr T.Text where


### PR DESCRIPTION
Resolves https://github.com/kazu-yamamoto/logger/issues/147. This instance is a little unintuitive. The bytestring builder must be materialized to a lazy bytestring to give us access to the length. Rather than putting the original `Builder` argument in the `LogStr`, we create a new builder from this lazy bytestring. This avoids duplicating work, which helps when computation inside a `Builder` is expensive.