### PR TITLE
Allow the callback logger to be generic.

### DIFF
--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -1,5 +1,5 @@
 Name:                   fast-logger
-Version:                2.4.17
+Version:                3.0.0
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3

--- a/wai-logger/Network/Wai/Logger.hs
+++ b/wai-logger/Network/Wai/Logger.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP   #-}
+{-# LANGUAGE GADTs #-}
 
 -- | Apache style logger for WAI applications.
 --
@@ -44,7 +45,7 @@ module Network.Wai.Logger (
   , initLogger
   -- * Types
   , IPAddrSource(..)
-  , LogType(..)
+  , LogType'(..), LogType
   , FileLogSpec(..)
   -- * Utilities
   , showSockAddr


### PR DESCRIPTION
Some logger backends use structured data and the Haskell logger API can reflect this structure.  By forcing callback to always use `LogStr` these backends suffer added complexity and performance issues serializing and deserializing their types.