### PR TITLE
Fix thread-safe issue when using LogStdout in fast-logger

### DIFF
--- a/fast-logger/System/Log/FastLogger/FileIO.hs
+++ b/fast-logger/System/Log/FastLogger/FileIO.hs
@@ -22,9 +22,8 @@ getStderrFD = return stderr
 getStdoutFD :: IO FD
 getStdoutFD = return stdout
 
-writeRawBufferPtr2FD :: IORef FD -> Ptr Word8 -> Int -> IO Int
-writeRawBufferPtr2FD fdref bf len = do
-    fd <- readIORef fdref
+writeRawBufferPtr2FD :: FD -> Ptr Word8 -> Int -> IO Int
+writeRawBufferPtr2FD fd bf len =
     if isFDValid fd then
         fromIntegral <$> writeRawBufferPtr "write" fd bf 0 (fromIntegral len)
       else

--- a/fast-logger/System/Log/FastLogger/Logger.hs
+++ b/fast-logger/System/Log/FastLogger/Logger.hs
@@ -10,7 +10,7 @@ module System.Log.FastLogger.Logger (
   ) where
 
 
-import Control.Concurrent (MVar, newMVar, withMVar)
+import Control.Concurrent (MVar, newMVar, withMVar, withMVarMasked)
 import Foreign.Marshal.Alloc (allocaBytes)
 import Foreign.Ptr (plusPtr)
 
@@ -31,21 +31,21 @@ newLogger size = Logger size <$> (getBuffer size >>= newMVar)
 
 ----------------------------------------------------------------
 
-pushLog :: IORef FD -> Logger -> LogStr -> IO ()
-pushLog fdref logger@(Logger size mbuf ref) nlogmsg@(LogStr nlen nbuilder)
+pushLog :: MVar FD -> Logger -> LogStr -> IO ()
+pushLog fdmv logger@(Logger size mbuf ref) nlogmsg@(LogStr nlen _nbuilder)
   | nlen > size = do
-      flushLog fdref logger
+      flushLog fdmv logger
       -- Make sure we have a large enough buffer to hold the entire
       -- contents, thereby allowing for a single write system call and
       -- avoiding interleaving. This does not address the possibility
       -- of write not writing the entire buffer at once.
       allocaBytes nlen $ \buf -> withMVar mbuf $ \_ ->
-        toBufIOWith buf nlen (write fdref) nbuilder
+        writeLogStr fdmv buf nlen nlogmsg
   | otherwise = do
     mmsg <- atomicModifyIORef' ref checkBuf
     case mmsg of
         Nothing  -> return ()
-        Just msg -> withMVar mbuf $ \buf -> writeLogStr fdref buf size msg
+        Just msg -> withMVar mbuf $ \buf -> writeLogStr fdmv buf size msg
   where
     checkBuf ologmsg@(LogStr olen _)
       | size < olen + nlen = (nlogmsg, Just ologmsg)
@@ -53,8 +53,8 @@ pushLog fdref logger@(Logger size mbuf ref) nlogmsg@(LogStr nlen nbuilder)
 
 ----------------------------------------------------------------
 
-flushLog :: IORef FD -> Logger -> IO ()
-flushLog fdref (Logger size mbuf lref) = do
+flushLog :: MVar FD -> Logger -> IO ()
+flushLog fdmv (Logger size mbuf lref) = do
     logmsg <- atomicModifyIORef' lref (\old -> (mempty, old))
     -- If a special buffer is prepared for flusher, this MVar could
     -- be removed. But such a code does not contribute logging speed
@@ -62,26 +62,34 @@ flushLog fdref (Logger size mbuf lref) = do
     -- there is no grantee that this function is exclusively called
     -- for a buffer. So, we use MVar here.
     -- This is safe and speed penalty can be ignored.
-    withMVar mbuf $ \buf -> writeLogStr fdref buf size logmsg
+    withMVar mbuf $ \buf -> writeLogStr fdmv buf size logmsg
 
 ----------------------------------------------------------------
 
 -- | Writting 'LogStr' using a buffer in blocking mode.
 --   The size of 'LogStr' must be smaller or equal to
 --   the size of buffer.
-writeLogStr :: IORef FD
+writeLogStr :: MVar FD
             -> Buffer
             -> BufSize
             -> LogStr
             -> IO ()
-writeLogStr fdref buf size (LogStr len builder)
-  | size < len = error "writeLogStr"
-  | otherwise  = toBufIOWith buf size (write fdref) builder
+writeLogStr fdmv buf size (LogStr len builder)
+  | size < len = error $ mconcat
+    [ "writeLogStr: Message length is longer than expected size (buf size: "
+    , show size
+    , ", msg len: "
+    , show len
+    , ")"
+    ]
+  | otherwise  =
+    -- NOTE: Guard fd for thread-safe even if async exceptions are thrown to this thread
+    withMVarMasked fdmv $ \fd -> toBufIOWith buf size (write fd) builder
 
-write :: IORef FD -> Buffer -> Int -> IO ()
-write fdref buf len' = loop buf (fromIntegral len')
+write :: FD -> Buffer -> Int -> IO ()
+write fd buf len' = loop buf (fromIntegral len')
   where
     loop bf !len = do
-        written <- writeRawBufferPtr2FD fdref bf len
+        written <- writeRawBufferPtr2FD fd bf len
         when (0 <= written && written < len) $
             loop (bf `plusPtr` fromIntegral written) (len - written)


### PR DESCRIPTION
## Summary

`pushLog` can be run in some threads in parallel. But fast-logger doesn't guard `FD` in logging, then several threads can write to FD simultaneously. `FD` must be guarded during writing a log message.
So I've replaced `IORef` with `MVar` to guard `FD` in this PR.


## Reproduction

MacOS: 10.15.7 (But the same problem occurs on Linux)
Physical cores: 6

I think this issue might appear for all LogTypes but I can't reproduce this problem when using `LogFileNoRotate`. I don't know why but this problem seems to appear when using `LogStdout` or `LogStderr`.

```
import System.Log.FastLogger
import Control.Concurrent
import Control.Monad

main = do
    getNumCapabilities >>= print
--    let logtype1 = (LogFileNoRotate "./log" 400)
    let logtype2 = (LogStdout 400)
    withFastLogger logtype2 $ \ logFn -> do
        forM_ [0..9] $ \n -> forkIO $ forM_ [1..800] $ \_ -> do
            let msg = toLogStr $ (mconcat $ replicate 40 (show n)) <> "\n"
            logFn msg

        threadDelay $ 1000000 * 2
```

result: Sometimes broken log messages appear.

```
12
...(omit)...
7777777777777777777777777777777777777777
7777777777777777777777777777777777777777
7777777777777777777777777777777777777777
7777777777777777777777777777777777777777
77777777777777777777772222222222222222222222222222222222222222
2222222222222222222222222222222222222222
2222222222222222222222222222222222222222
2222222222222222222222222222222222222222
2222222222222222222222222222222222222222
2222222222222222222222222222222222222222
5555555555555555555555555555555555555555
5555555555555555555555555555555555555555
5555555555555555555555555555555555555555
5555555555555555555555555555555555555555
5555555555555555555555555555555555555555
9999999999999999999999999999999999999999
777777777777777777
7777777777777777777777777777777777777777
6666666666666666666666666666666666666666
6666666666666666666666666666666666666666
6666666666666666666666666666666666666666
...(omit)...
```

