### PR TITLE
Add ability to log current user via getter

### DIFF
--- a/wai-logger/Network/Wai/Logger/Apache.hs
+++ b/wai-logger/Network/Wai/Logger/Apache.hs
@@ -41,10 +41,12 @@ data IPAddrSource =
   | FromFallback
 
 -- | Apache style log format.
-apacheLogStr :: IPAddrSource -> FormattedTime -> Request -> Status -> Maybe Integer -> LogStr
-apacheLogStr ipsrc tmstr req status msize =
+apacheLogStr :: ToLogStr user => IPAddrSource -> (Request -> Maybe user) -> FormattedTime -> Request -> Status -> Maybe Integer -> LogStr
+apacheLogStr ipsrc userget tmstr req status msize =
       toLogStr (getSourceIP ipsrc req)
-  <> " - - ["
+  <> " - "
+  <> maybe "-" toLogStr (userget req)
+  <> " ["
   <> toLogStr tmstr
   <> "] \""
   <> toLogStr (requestMethod req)
@@ -75,10 +77,12 @@ apacheLogStr ipsrc tmstr req status msize =
 #endif
 
 -- | HTTP/2 Push log format in the Apache style.
-serverpushLogStr :: IPAddrSource -> FormattedTime -> Request -> ByteString -> Integer -> LogStr
-serverpushLogStr ipsrc tmstr req path size =
+serverpushLogStr :: ToLogStr user => IPAddrSource -> (Request -> Maybe user) -> FormattedTime -> Request -> ByteString -> Integer -> LogStr
+serverpushLogStr ipsrc userget tmstr req path size =
       toLogStr (getSourceIP ipsrc req)
-  <> " - - ["
+  <> " - "
+  <> maybe "-" toLogStr (userget req)
+  <> " ["
   <> toLogStr tmstr
   <> "] \"PUSH "
   <> toLogStr path


### PR DESCRIPTION
The ["Common Log Format"](https://httpd.apache.org/docs/current/logs.html#common) used by apache is supposed to show the current user "as determined by HTTP authentication". This is not implemented in `wai-logger`, yet:

https://github.com/kazu-yamamoto/logger/blob/cde8404e9f37a0202655f99da04fd5326d9ea6c7/wai-logger/Network/Wai/Logger/Apache.hs#L81

The second `-` is supposed to be the user.

Since there is, afaik, no "WAI standard" on how to get that user, this PR adds the ability to pass in a getter to `initLogger` which will then read the current user from the `Request`. This would allow to pass in a helper around `wai-middleware-auth`'s `getAuthUser` or allow to do something similar in PostgREST (https://github.com/PostgREST/postgrest/pull/1988).

If this was merged, I'd follow up with a PR to `wai-extra` to make it available in `mkRequestLogger`.