### PR TITLE
More time-ordered logging functions, fix `newFastLogger1`

### DIFF
--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -117,8 +117,8 @@ newFastLogger1 typ = newFastLoggerCore (Just 1) typ
 newFastLoggerCore :: Maybe Int -> LogType' v -> IO (v -> IO (), IO ())
 newFastLoggerCore mn typ = case typ of
     LogNone                        -> return (const noOp, noOp)
-    LogStdout bsize                -> newStdoutLoggerSet bsize >>= stdLoggerInit
-    LogStderr bsize                -> newStderrLoggerSet bsize >>= stdLoggerInit
+    LogStdout bsize                -> newStdoutLoggerSetN bsize mn >>= stdLoggerInit
+    LogStderr bsize                -> newStderrLoggerSetN bsize mn >>= stdLoggerInit
     LogFileNoRotate fp bsize       -> newFileLoggerSetN bsize mn fp >>= fileLoggerInit
     LogFile fspec bsize            -> rotateLoggerInit fspec bsize
     LogFileTimedRotate fspec bsize -> timedRotateLoggerInit fspec bsize

--- a/fast-logger/System/Log/FastLogger.hs
+++ b/fast-logger/System/Log/FastLogger.hs
@@ -101,9 +101,16 @@ data LogType' a where
 -- This type signature should be read as:
 --
 -- > newFastLogger :: LogType -> IO (FastLogger, IO ())
+--
+-- This logger uses `numCapabilities` many buffers, and thus
+-- does not provide time-ordered output.
+-- For time-ordered output, use `newFastLogger1`.
 newFastLogger :: LogType' v -> IO (v -> IO (), IO ())
 newFastLogger typ = newFastLoggerCore Nothing typ
 
+-- | Like `newFastLogger`, but creating a logger that uses only 1
+-- capability. This scales less well on multi-core machines,
+-- but provides time-ordered output.
 newFastLogger1 :: LogType' v -> IO (v -> IO (), IO ())
 newFastLogger1 typ = newFastLoggerCore (Just 1) typ
 

--- a/fast-logger/System/Log/FastLogger/LoggerSet.hs
+++ b/fast-logger/System/Log/FastLogger/LoggerSet.hs
@@ -8,6 +8,7 @@ module System.Log.FastLogger.LoggerSet (
   , newStdoutLoggerSet
   , newStderrLoggerSet
   , newLoggerSet
+  , newFDLoggerSet
   -- * Renewing and removing a logger set
   , renewLoggerSet
   , rmLoggerSet


### PR DESCRIPTION
See individual commits.

Fixes https://github.com/kazu-yamamoto/logger/commit/6ddf3c789f36133aa68ef256e2c9b23150e41be6#r60660256.

Why is this change important?

For my logging use cases (and I'd argue, for many), I require time-ordered output. Until now, this was not configurable for stdout/stderr.