### PR TITLE
wai-logger: Make unix sockets known

### DIFF
--- a/wai-logger/Network/Wai/Logger/Apache.hs
+++ b/wai-logger/Network/Wai/Logger/Apache.hs
@@ -127,7 +127,7 @@ getSourceFromSocket = BS.pack . showSockAddr . remoteHost
 -- >>> getSourceFromHeader defaultRequest { requestHeaders = [] }
 -- ""
 getSourceFromHeader :: Request -> ByteString
-getSourceFromHeader = fromMaybe "" . getSource
+getSourceFromHeader = fromMaybe "-" . getSource
 
 -- |
 -- >>> getSourceFromFallback defaultRequest { requestHeaders = [ ("X-Real-IP", "127.0.0.1") ] }

--- a/wai-logger/Network/Wai/Logger/IP.hs
+++ b/wai-logger/Network/Wai/Logger/IP.hs
@@ -46,4 +46,4 @@ showSockAddr (SockAddrInet _ addr4)                       = showIPv4 addr4 (byte
 showSockAddr (SockAddrInet6 _ _ (0,0,0x0000ffff,addr4) _) = showIPv4 addr4 False
 showSockAddr (SockAddrInet6 _ _ (0,0,0,1) _)              = "::1"
 showSockAddr (SockAddrInet6 _ _ addr6 _)                  = showIPv6 addr6
-showSockAddr _                                            = "unknownSocket"
+showSockAddr (SockAddrUnix _)                             = "-"


### PR DESCRIPTION
Currently, when connected via unix socket, the logged request always starts with `unknownSocket - user ...`. This doesn't look good in the logs - I always have to remember what this is about and that this is indeed expected behaviour and not something going wrong with my server. Note: nginx logs `unix: - user ...` in that case. I understand that Apache itself doesn't support unix sockets, so I couldn't compare that.

It's arguably wrong, too: The socket is not unknown, it's just a unix socket. The concept of an IP, that we could display there, doesn't really apply. Other values that are missing like that in the log string are logged as `-`, that's what I went with here, too: `- - user ...`.

This is slightly inconsistent with how `getSourceFromHeader` returns the missing case:
https://github.com/kazu-yamamoto/logger/blob/9db4c009a957169d6dcc7c6418e9c90524e4b273/wai-logger/Network/Wai/Logger/Apache.hs#L130

Maybe change that, too? Or, change `unknownSocket` to an empty string - however, it's not as easy to tell from the log, when it starts with a space: ` - user ...`.