### PR TITLE
Require unix-compat >= 0.2

### DIFF
--- a/fast-logger/fast-logger.cabal
+++ b/fast-logger/fast-logger.cabal
@@ -36,7 +36,7 @@ Library
                       , filepath
                       , text
                       , unix-time >= 0.4.4
-                      , unix-compat
+                      , unix-compat >= 0.2
   if impl(ghc < 7.8)
       Build-Depends:    bytestring-builder
   if impl(ghc >= 8)


### PR DESCRIPTION
`System.PosixCompat.Time` is not available before `unix-compat-0.2`.

As a Hackage trustee I made revisions to `fast-logger-3.0.3..3.1.1`.