### PR TITLE
Make `rmLoggerSet` flush also for `SingleLogger`

### DIFF
--- a/fast-logger/System/Log/FastLogger/SingleLogger.hs
+++ b/fast-logger/System/Log/FastLogger/SingleLogger.hs
@@ -100,6 +100,7 @@ flushAllLog SingleLogger{..} = do
     slgrWakeup
 
 stopLoggers :: SingleLogger -> IO ()
-stopLoggers SingleLogger{..} = do
+stopLoggers sl@SingleLogger{..} = do
+    System.Log.FastLogger.SingleLogger.flushAllLog sl
     slgrKill
     freeBuffer slgrBuffer


### PR DESCRIPTION
Fixes #208.

I have not tested this thoroughly, but it compiles and passes `stack test`.