### PR TITLE
Support custom HTTP header for IP address source

### DIFF
--- a/wai-logger/wai-logger.cabal
+++ b/wai-logger/wai-logger.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name:          wai-logger
-version:       2.4.0
+version:       2.4.1
 license:       BSD3
 license-file:  LICENSE
 maintainer:    Kazu Yamamoto <kazu@iij.ad.jp>


### PR DESCRIPTION
The case here is we use a proxy which replaces X-Real-IP with something not real and instead provides client's IP address via a custom header.